### PR TITLE
update cljs profile jvm-options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -60,14 +60,13 @@
                                            "compile" ["with-profile" "cljs" "run" "-m" "shadow.cljs.devtools.cli" "release" "main"]]}
              :production {}
              :cljs       {:source-paths ["src/main" "src/test" "src/cards"]
+                          :jvm-opts     ["-XX:-OmitStackTraceInFastThrow" "-Xmx1g"]
                           :dependencies [[binaryage/devtools "0.9.10"]
                                          [org.clojure/clojurescript "1.10.520"]
                                          [fulcrologic/fulcro-inspect "2.2.4"]]}
              :dev        {:source-paths ["src/dev" "src/main" "src/test" "src/cards"]
                           :jvm-opts     ["-XX:-OmitStackTraceInFastThrow" "-Xmx1g"]
-
                           :plugins      [[com.jakemccrary/lein-test-refresh "0.23.0"]]
-
                           :dependencies [[org.clojure/tools.namespace "0.3.0-alpha4"]
                                          [org.clojure/tools.nrepl "0.2.13"]
                                          [cider/piggieback "0.3.10"]]


### PR DESCRIPTION
This is an attempt to make adjustments to the build so that I can test in the Jenkins sandbox.

- adjusted jvm-options for the `cljs` profile used during build to hopefully fix spurious `OutOfMemoryError` thrown by the build JVM
- adjusted `Dockerfile` to explicitly use `golang:1.10-alpine` (as the go 1.10 coming in from `apk add go` on alpine 3.8 seemed to be what is neeced to build the go-ui-server. also, one less thing to install therefore should be a slightly faster build)
- adjusted `Dockerfile` to rely on `clojure:lein` (non-alpinew) because that should have proper ARM64 support (was failing to pull `clojure:lein-2.7.1-alpine` for arm64 arch)

Signed-off-by: Jacob Blain Christen <jacob.blain.christen@intel.com>