### PR TITLE
Use cookie to track login state

### DIFF
--- a/src/go/src/github.com/edgexfoundry/go-ui-server/internal/edgex/services.go
+++ b/src/go/src/github.com/edgexfoundry/go-ui-server/internal/edgex/services.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -20,7 +19,10 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/go-ui-server/internal/fulcro"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/russolsen/transit"
+
 	"golang.org/x/crypto/bcrypt"
 
 	"gopkg.in/resty.v1"
@@ -60,8 +62,10 @@ func Login(params []interface{}, args map[interface{}]interface{}) (interface{},
 	if (bcrypt.CompareHashAndPassword(existing, incoming) != nil) {
 		return  nil, errors.New("Invalid Password")
 	}
+	session_id, _ := uuid.NewUUID()
+	result := map[transit.Keyword]string{transit.Keyword("session_id"): session_id.String()}
 
-	return nil, nil
+	return result, nil
 }
 
 func ChangePassword(params []interface{}, args map[interface{}]interface{}) (interface{}, error) {

--- a/src/main/org/edgexfoundry/ui/manager/ui/root.cljs
+++ b/src/main/org/edgexfoundry/ui/manager/ui/root.cljs
@@ -387,7 +387,6 @@
                             :ui/endpoint-modal (prim/get-initial-state ep/EndpointModal {})
                             :ui/logout-modal    (prim/get-initial-state lg/LogoutModal {})
                             :top-router         (prim/get-initial-state TopRouter {})
-                            :logged-in?          false
                             :pw-updated?         false}
                            r/app-routing-tree))
    :query         [:ui/locale :ui/react-key
@@ -400,7 +399,6 @@
                    {:top-router         (prim/get-query TopRouter)}
                    :ui/loading-data
                    fulcro.client.routing/routing-tree-key
-                   :logged-in?
                    :pw-updated?]}
   (let [delete-cbs {:da-modal a/do-delete-addressable
                     :dd-modal dv/do-delete-device

--- a/src/main/org/edgexfoundry/ui/manager/ui/routing.cljs
+++ b/src/main/org/edgexfoundry/ui/manager/ui/routing.cljs
@@ -10,7 +10,8 @@
     [sibiro.core :as sibiro]
     [fulcro.client.primitives :as prim]
     [fulcro.client.logging :as log]
-    [org.edgexfoundry.ui.manager.ui.common :as co]))
+    [org.edgexfoundry.ui.manager.ui.common :as co]
+    [goog.net.cookies :as cks]))
 
 (def app-routing-tree
   (r/routing-tree
@@ -89,6 +90,11 @@
       state-map)
     (r/update-routing-links state-map sibiro-match)))
 
+(defn is-logged-in?
+  []
+  (let [cookie (cks/get "EDGEX_SESSION_ID")]
+    cookie))
+
 (defn set-route!*
   "Implementation of choosing a particular sibiro match. Used internally by the HTML5 history event implementation.
   Updates the UI only, unless the URI is invalid, in which case it redirects the UI and possibly generates new HTML5
@@ -98,9 +104,9 @@
         sm {:handler handler :route-params rp}]
     (cond
       (or (= :login handler)) (r/update-routing-links state-map sibiro-match)
-      (not (:logged-in? state-map)) (-> state-map
-                                        (assoc :loaded-uri (when @history (pushy/get-token @history)))
-                                        (redirect* {:handler :login}))
+      (not (is-logged-in?)) (-> state-map
+                                (assoc :loaded-uri (when @history (pushy/get-token @history)))
+                                (redirect* {:handler :login}))
       (invalid-route? handler) (redirect* state-map {:handler :main})
       :else (-> state-map
                 (r/update-routing-links sm)


### PR DESCRIPTION
Use cookie to keep the session after refreshing the browser. Fix #22.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>